### PR TITLE
HB-4

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,9 +1,11 @@
-import { Command } from "./command";
-import { Emmit } from './admin/Emmit';
+import {Command} from "./command";
+import {Emmit} from './admin/Emmit';
 import {Warn} from "./moderation/Warn";
 import {Sanctions} from "./moderation/Sanction";
 import {Mute} from "./moderation/Mute";
 import {UnMute} from "./moderation/UnMute";
 import {Clear} from "./moderation/Clear";
+import {Ban} from "./moderation/Ban";
+import {UnBan} from "./moderation/UnBan";
 
-export const Commands: Command[] = [Emmit, Warn, Sanctions, Mute, UnMute, Clear];
+export const Commands: Command[] = [Emmit, Warn, Sanctions, Mute, UnMute, Clear, Ban, UnBan];

--- a/src/commands/moderation/Ban.ts
+++ b/src/commands/moderation/Ban.ts
@@ -3,5 +3,47 @@ import {SlashCommandBuilder} from "discord.js";
 import {AppDataSource} from "../../data-source";
 import {Logs, Sanction} from "../../entities/logs";
 import {Guild} from "../../entities/guild";
+import lang from "../../lang";
 
-// TODO: Implement the UnMute command
+export const Ban: Command = {
+    data: new SlashCommandBuilder()
+        .setName(lang.moderation.ban['en-US'])
+        .setNameLocalizations(lang.moderation.ban)
+        .setDescription(lang.moderation.ban_description['en-US'])
+        .setDescriptionLocalizations(lang.moderation.ban_description)
+        .addUserOption(option => option
+            .setName(lang.user['en-US'])
+            .setNameLocalizations(lang.user)
+            .setDescription(lang.user_description['en-US'])
+            .setDescriptionLocalizations(lang.user_description)
+            .setRequired(true))
+        .addStringOption(option => option
+            .setName(lang.reason['en-US'])
+            .setNameLocalizations(lang.reason)
+            .setDescription(lang.reason_description['en-US'])
+            .setDescriptionLocalizations(lang.reason_description)
+            .setRequired(true)),
+    run: async (client, interaction) => {
+        // @ts-ignore
+        const user = interaction.options.getMember(lang.user['en-US']);
+        // @ts-ignore
+        const reason = interaction.options.getString(lang.reason['en-US']);
+
+        if (!user) {
+            await interaction.reply({content: 'An error has occurred', ephemeral: true});
+            return;
+        }
+
+        const logsRepo = AppDataSource.getRepository(Logs);
+        const guildRepo = AppDataSource.getRepository(Guild);
+        const logs = new Logs();
+        logs.guild = await guildRepo.findOneBy({id: interaction.guildId});
+        logs.userId = user.id;
+        logs.reason = reason;
+        logs.sanction = Sanction.BAN;
+        logsRepo.save(logs);
+
+        await user.ban({reason: reason});
+        await interaction.reply({content: `Banned ${user.tag} for ${reason}`});
+    }
+}

--- a/src/commands/moderation/Mute.ts
+++ b/src/commands/moderation/Mute.ts
@@ -14,28 +14,28 @@ export const Mute: Command = {
         .setDescription(lang.moderation.mute_description["en-US"])
         .setDescriptionLocalizations(lang.moderation.mute_description)
         .addUserOption(option => option
-            .setName(lang.moderation.user["en-US"])
-            .setNameLocalizations(lang.moderation.user)
-            .setDescription(lang.moderation.user_description["en-US"])
-            .setDescriptionLocalizations(lang.moderation.user_description)
+            .setName(lang.user["en-US"])
+            .setNameLocalizations(lang.user)
+            .setDescription(lang.user_description["en-US"])
+            .setDescriptionLocalizations(lang.user_description)
             .setRequired(true))
         .addStringOption(option => option
-            .setName(lang.moderation.duration['en-US'])
-            .setNameLocalizations(lang.moderation.duration)
-            .setDescription(lang.moderation.duration_description['en-US'])
-            .setDescriptionLocalizations(lang.moderation.duration_description).setRequired(true))
+            .setName(lang.duration['en-US'])
+            .setNameLocalizations(lang.duration)
+            .setDescription(lang.duration_description['en-US'])
+            .setDescriptionLocalizations(lang.duration_description).setRequired(true))
         .addStringOption(option => option
-            .setName(lang.moderation.reason["en-US"])
-            .setNameLocalizations(lang.moderation.reason)
-            .setDescription(lang.moderation.reason_description["en-US"])
-            .setDescriptionLocalizations(lang.moderation.reason_description)),
+            .setName(lang.reason["en-US"])
+            .setNameLocalizations(lang.reason)
+            .setDescription(lang.reason_description["en-US"])
+            .setDescriptionLocalizations(lang.reason_description)),
     run: async (client, interaction) => {
         // @ts-ignore
-        const member: GuildMember = interaction.options.getMember(lang.moderation.user['en-US']);
+        const member: GuildMember = interaction.options.getMember(lang.user['en-US']);
         // @ts-ignore
-        const reason = interaction.options.getString(lang.moderation.reason['en-US']) || 'No reason provided';
+        const reason = interaction.options.getString(lang.reason['en-US']) || 'No reason provided';
         // @ts-ignore
-        const duration = interaction.options.getString(lang.moderation.duration['en-US']);
+        const duration = interaction.options.getString(lang.duration['en-US']);
         if (!member) {
             await interaction.reply({content: 'An error has occurred', ephemeral: true});
             return;

--- a/src/commands/moderation/Sanction.ts
+++ b/src/commands/moderation/Sanction.ts
@@ -11,14 +11,14 @@ export const Sanctions: Command = {
         .setDescription(lang.moderation.sanction_description['en-US'])
         .setDescriptionLocalizations(lang.moderation.sanction_description)
         .addUserOption(option => option
-            .setName(lang.moderation.user['en-US'])
-            .setNameLocalizations(lang.moderation.user)
-            .setDescription(lang.moderation.user_description['en-US'])
-            .setDescriptionLocalizations(lang.moderation.user_description)
+            .setName(lang.user['en-US'])
+            .setNameLocalizations(lang.user)
+            .setDescription(lang.user_description['en-US'])
+            .setDescriptionLocalizations(lang.user_description)
             .setRequired(true)),
     run: async (client, interaction) => {
         // @ts-ignore
-        const user = interaction.options.getUser(lang.moderation.user['en-US']);
+        const user = interaction.options.getUser(lang.user['en-US']);
         if (!user) {
             await interaction.reply({content: 'An error has occurred', ephemeral: true});
             return;

--- a/src/commands/moderation/UnBan.ts
+++ b/src/commands/moderation/UnBan.ts
@@ -1,7 +1,41 @@
 import {Command} from "../command";
-import {SlashCommandBuilder} from "discord.js";
+import {GuildMember, SlashCommandBuilder, User} from "discord.js";
 import {AppDataSource} from "../../data-source";
 import {Logs, Sanction} from "../../entities/logs";
 import {Guild} from "../../entities/guild";
+import lang from "../../lang";
 
-// TODO: Implement the UnMute command
+export const UnBan: Command = {
+    data: new SlashCommandBuilder()
+        .setName(lang.moderation.unban['en-US'])
+        .setNameLocalizations(lang.moderation.unban)
+        .setDescription(lang.moderation.unban_description['en-US'])
+        .setDescriptionLocalizations(lang.moderation.unban_description)
+        .addUserOption(option => option
+            .setName(lang.user['en-US'])
+            .setNameLocalizations(lang.user)
+            .setDescription(lang.user_description['en-US'])
+            .setDescriptionLocalizations(lang.user_description)
+            .setRequired(true)),
+    run: async (client, interaction) => {
+        // @ts-ignore
+        const user: User = interaction.options.getUser(lang.user['en-US']);
+
+        if (!user) {
+            await interaction.reply({content: 'An error has occurred', ephemeral: true});
+            return;
+        }
+
+        const logsRepo = AppDataSource.getRepository(Logs);
+        const guildRepo = AppDataSource.getRepository(Guild);
+        const logs = new Logs();
+        logs.guild = await guildRepo.findOneBy({id: interaction.guildId});
+        logs.userId = user.id;
+        logs.reason = "Unban";
+        logs.sanction = Sanction.BAN;
+        logsRepo.save(logs);
+
+        await interaction.guild.members.unban(user);
+        await interaction.reply({content: `Unbanned ${user.tag}`});
+    }
+}

--- a/src/commands/moderation/UnMute.ts
+++ b/src/commands/moderation/UnMute.ts
@@ -12,14 +12,14 @@ export const UnMute: Command = {
         .setDescription(lang.moderation.unmute_description["en-US"])
         .setDescriptionLocalizations(lang.moderation.unmute_description)
         .addUserOption(option => option
-            .setName(lang.moderation.user["en-US"])
-            .setNameLocalizations(lang.moderation.user)
-            .setDescription(lang.moderation.user_description["en-US"])
-            .setDescriptionLocalizations(lang.moderation.user_description)
+            .setName(lang.user["en-US"])
+            .setNameLocalizations(lang.user)
+            .setDescription(lang.user_description["en-US"])
+            .setDescriptionLocalizations(lang.user_description)
             .setRequired(true)),
     run: async (client, interaction) => {
         // @ts-ignore
-        const user: GuildMember = interaction.options.getMember(lang.moderation.user['en-US']);
+        const user: GuildMember = interaction.options.getMember(lang.user['en-US']);
         if (!user) {
             await interaction.reply({content: 'An error has occurred', ephemeral: true});
             return;

--- a/src/commands/moderation/Warn.ts
+++ b/src/commands/moderation/Warn.ts
@@ -11,20 +11,20 @@ export const Warn: Command = {
         .setNameLocalizations(lang.moderation.warn)
         .setDescription(lang.moderation.warn_description["en-US"])
         .setDescriptionLocalizations(lang.moderation.warn_description)
-        .addUserOption(option => option.setName(lang.moderation.user["en-US"])
-            .setNameLocalizations(lang.moderation.user)
-            .setDescription(lang.moderation.user_description["en-US"])
-            .setDescriptionLocalizations(lang.moderation.user_description)
+        .addUserOption(option => option.setName(lang.user["en-US"])
+            .setNameLocalizations(lang.user)
+            .setDescription(lang.user_description["en-US"])
+            .setDescriptionLocalizations(lang.user_description)
             .setRequired(true))
-        .addStringOption(option => option.setName(lang.moderation.reason["en-US"])
-            .setNameLocalizations(lang.moderation.reason)
-            .setDescription(lang.moderation.reason_description["en-US"])
-            .setDescriptionLocalizations(lang.moderation.reason_description)),
+        .addStringOption(option => option.setName(lang.reason["en-US"])
+            .setNameLocalizations(lang.reason)
+            .setDescription(lang.reason_description["en-US"])
+            .setDescriptionLocalizations(lang.reason_description)),
     run: async (client, interaction) => {
         // @ts-ignore
-        const user = interaction.options.getUser(lang.moderation.user['en-US']);
+        const user = interaction.options.getUser(lang.user['en-US']);
         // @ts-ignore
-        const reason = interaction.options.getString(lang.moderation.reason['en-US']);
+        const reason = interaction.options.getString(lang.reason['en-US']);
         if (!user) {
             await interaction.reply({content: 'An error has occurred', ephemeral: true});
             return;

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -50,54 +50,6 @@ export default {
         }
     },
     "moderation": {
-        "user": {
-            "en-US": "user",
-            "de": "benutzer",
-            "ru": "пользователь",
-            "pt-BR": "usuário",
-            "nl": "gebruiker",
-            "fr": "utilisateur"
-        },
-        "user_description": {
-            "en-US": "Select a user",
-            "de": "Wählen Sie einen Benutzer",
-            "ru": "Выберите пользователя",
-            "pt-BR": "Selecione um usuário",
-            "nl": "Selecteer een gebruiker",
-            "fr": "Sélectionnez un utilisateur"
-        },
-        "reason": {
-            "en-US": "reason",
-            "de": "grund",
-            "ru": "причина",
-            "pt-BR": "razão",
-            "nl": "reden",
-            "fr": "raison"
-        },
-        "reason_description": {
-            "en-US": "The reason for the warning",
-            "de": "Der Grund für die Warnung",
-            "ru": "Причина предупреждения",
-            "pt-BR": "O motivo do aviso",
-            "nl": "De reden voor de waarschuwing",
-            "fr": "La raison de l'avertissement"
-        },
-        "duration": {
-            "en-US": "duration",
-            "de": "dauer",
-            "ru": "продолжительность",
-            "pt-BR": "duração",
-            "nl": "duur",
-            "fr": "durée"
-        },
-        "duration_description": {
-            "en-US": "The duration of the mute (e.g. 1d, 1h, 1m)",
-            "de": "Die Dauer des Stummschaltens (z. B. 1d, 1h, 1m)",
-            "ru": "Продолжительность заглушения (например, 1д, 1ч, 1м)",
-            "pt-BR": "A duração do mute (ex. 1d, 1h, 1m)",
-            "nl": "De duur van de demping (bijv. 1d, 1h, 1m)",
-            "fr": "La durée du mute (par exemple 1d, 1h, 1m)"
-        },
         "warn": {
             "en-US": "warn",
             "de": "warnen",
@@ -162,8 +114,7 @@ export default {
             "nl": "krijg lijst van sancties voor een gebruiker",
             "fr": "obtenir la liste des sanctions pour un utilisateur"
         },
-        "clear":
-        {
+        "clear": {
             "en-US": "clear",
             "fr": "supprimer",
             "de": "löschen",
@@ -178,6 +129,38 @@ export default {
             "ru": "Очищает количество сообщений или канал",
             "pt-BR": "Limpa um número de mensagens ou um canal",
             "nl": "Wist een aantal berichten of een kanaal"
+        },
+        "ban": {
+            "en-US": "ban",
+            "de": "verbot",
+            "ru": "запрет",
+            "pt-BR": "proibição",
+            "nl": "verbod",
+            "fr": "bannir"
+        },
+        "ban_description": {
+            "en-US": "Ban a user",
+            "de": "Einen Benutzer verbieten",
+            "ru": "Запретить пользователя",
+            "pt-BR": "Banir um usuário",
+            "nl": "Een gebruiker verbannen",
+            "fr": "Bannir un utilisateur"
+        },
+        "unban": {
+            "en-US": "unban",
+            "de": "entbannen",
+            "ru": "разбанить",
+            "pt-BR": "desbanir",
+            "nl": "unban",
+            "fr": "débannir"
+        },
+        "unban_description": {
+            "en-US": "Unban a user",
+            "de": "Einen Benutzer entbannen",
+            "ru": "Разбанить пользователя",
+            "pt-BR": "Desbanir um usuário",
+            "nl": "Unban een gebruiker",
+            "fr": "Débannir un utilisateur"
         },
     },
     "amount": {
@@ -211,5 +194,53 @@ export default {
         "ru": "Все для команды",
         "pt-BR": "Todos para o comando",
         "nl": "Alles voor de opdracht"
-    }
+    },
+    "user": {
+        "en-US": "user",
+        "de": "benutzer",
+        "ru": "пользователь",
+        "pt-BR": "usuário",
+        "nl": "gebruiker",
+        "fr": "utilisateur"
+    },
+    "user_description": {
+        "en-US": "Select a user",
+        "de": "Wählen Sie einen Benutzer",
+        "ru": "Выберите пользователя",
+        "pt-BR": "Selecione um usuário",
+        "nl": "Selecteer een gebruiker",
+        "fr": "Sélectionnez un utilisateur"
+    },
+    "reason": {
+        "en-US": "reason",
+        "de": "grund",
+        "ru": "причина",
+        "pt-BR": "razão",
+        "nl": "reden",
+        "fr": "raison"
+    },
+    "reason_description": {
+        "en-US": "The reason for the warning",
+        "de": "Der Grund für die Warnung",
+        "ru": "Причина предупреждения",
+        "pt-BR": "O motivo do aviso",
+        "nl": "De reden voor de waarschuwing",
+        "fr": "La raison de l'avertissement"
+    },
+    "duration": {
+        "en-US": "duration",
+        "de": "dauer",
+        "ru": "продолжительность",
+        "pt-BR": "duração",
+        "nl": "duur",
+        "fr": "durée"
+    },
+    "duration_description": {
+        "en-US": "The duration of the mute (e.g. 1d, 1h, 1m)",
+        "de": "Die Dauer des Stummschaltens (z. B. 1d, 1h, 1m)",
+        "ru": "Продолжительность заглушения (например, 1д, 1ч, 1м)",
+        "pt-BR": "A duração do mute (ex. 1d, 1h, 1m)",
+        "nl": "De duur van de demping (bijv. 1d, 1h, 1m)",
+        "fr": "La durée du mute (par exemple 1d, 1h, 1m)"
+    },
 } as const;


### PR DESCRIPTION
✨ (commands): Add Ban and UnBan commands to the list of available commands
🐛 (Ban.ts, UnBan.ts): Implement Ban and UnBan commands to allow moderators to ban and unban users
♻️ (Mute.ts, Sanction.ts, UnMute.ts, Warn.ts): Refactor command options to use generic 'user' and 'reason' instead of 'moderation.user' and 'moderation.reason' for better code readability and maintainability

🌐 (lang.ts): Refactor language structure for better organization
✨ (lang.ts): Add 'ban' and 'unban' translations for user moderation
♻️ (lang.ts): Move 'user', 'user_description', 'reason', 'reason_description', 'duration', 'duration_description' to root level for better accessibility